### PR TITLE
Add customizable site title via SITE_TITLE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ to use images reference using the /local/ path like this
 <img src=/local/yeah.png>
 ```
 
+### Custom site title
+
+you can set the browser tab title by passing the `SITE_TITLE` environment variable (defaults to `SimpleIPAM`)
+
+```
+docker run --name simpleipam  \
+--restart always  \
+-e SITE_TITLE="My Network" \
+-v ./ipam.db:/simpleipam/sqlite/ipam.db \
+-p 888:888 \
+-d ghcr.io/teamzuzu/simpleipam:master
+```
+
 ### Docker compose
 
 you'll need to touch ipam.db and mkdir local and create an index.html
@@ -56,6 +69,8 @@ services:
   simpleipam:
     container_name: simpleipam
     restart: always
+    environment:
+      - SITE_TITLE=My Network
     volumes:
       - ./ipam.db:/simpleipam/sqlite/ipam.db
       - ./local/:/simpleipam/local/
@@ -65,14 +80,14 @@ services:
 networks: {}
 ```
 
-### Helm 
+### Helm
 
 values can be found here https://raw.githubusercontent.com/teamzuzu/simpleipam/refs/heads/master/chart/values.yaml
 
 ```
 helm repo add teamzuzu https://teamzuzu.github.io/simpleipam/
 helm repo update
-helm install teamzuzu/simpleipam
+helm install teamzuzu/simpleipam --set siteTitle="My Network"
 ```
 
 ## Changes

--- a/application/views/hosts_view.php
+++ b/application/views/hosts_view.php
@@ -1,4 +1,5 @@
-<title>SimpleIPAM Hosts</title>
+<?php $site_title = getenv('SITE_TITLE') ?: 'SimpleIPAM'; ?>
+<title><?php echo htmlspecialchars($site_title); ?> Hosts</title>
 <div class="container">
 
   <h2>Hosts</h2>

--- a/application/views/networks_view.php
+++ b/application/views/networks_view.php
@@ -1,4 +1,5 @@
-<title> SimpleIPAM Networks </title>
+<?php $site_title = getenv('SITE_TITLE') ?: 'SimpleIPAM'; ?>
+<title><?php echo htmlspecialchars($site_title); ?> Networks</title>
 <div class="container">
 
     <h2>Networks</h2>

--- a/application/views/template/header.php
+++ b/application/views/template/header.php
@@ -14,7 +14,8 @@
       <div class="container">
 
 	<div id="navbar-header">
-  <a class="navbar-brand" href="<?php echo base_url('/') ?>"><b>SimpleIPAM</b></a>
+<?php $site_title = getenv('SITE_TITLE') ?: 'SimpleIPAM'; ?>
+  <a class="navbar-brand" href="<?php echo base_url('/') ?>"><b><?php echo htmlspecialchars($site_title); ?></b></a>
 </div>
 	  <ul class="nav navbar-nav">
              <li><a href="<?php echo base_url('/') ?>Hosts">hosts</a></li>

--- a/application/views/top_view.php
+++ b/application/views/top_view.php
@@ -1,4 +1,5 @@
-<title> SimpleIPAM </title>
+<?php $site_title = getenv('SITE_TITLE') ?: 'SimpleIPAM'; ?>
+<title><?php echo htmlspecialchars($site_title); ?></title>
 <div class="container">
 <?php 
 include "local/index.html";

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
         - name: simpleipam
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: SITE_TITLE
+              value: {{ .Values.siteTitle | quote }}
           ports:
             - containerPort: {{ .Values.service.port }}
           volumeMounts:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,3 +1,5 @@
+siteTitle: "SimpleIPAM"
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
## Summary
This PR adds support for customizing the browser tab and navbar title throughout the SimpleIPAM application via the `SITE_TITLE` environment variable, defaulting to "SimpleIPAM" if not specified.

## Key Changes
- **Application Views**: Updated all view files (`hosts_view.php`, `networks_view.php`, `top_view.php`, and `header.php`) to read the `SITE_TITLE` environment variable and display it dynamically in page titles and the navbar brand
- **Security**: Implemented `htmlspecialchars()` escaping on all dynamic title outputs to prevent XSS vulnerabilities
- **Documentation**: Added comprehensive examples in README.md showing how to set `SITE_TITLE` in both Docker run commands and Docker Compose configurations
- **Helm Chart**: Updated Helm deployment template and values.yaml to support the `siteTitle` parameter, allowing users to customize the title during Helm installation
- **Minor Fixes**: Cleaned up whitespace inconsistencies in Helm documentation section

## Implementation Details
- The `SITE_TITLE` environment variable is read using `getenv()` with a fallback to the default "SimpleIPAM" value
- All user-supplied title values are properly escaped using `htmlspecialchars()` to prevent injection attacks
- The implementation is consistent across all views and the header template
- Helm users can now pass `--set siteTitle="My Network"` during installation to customize the title

https://claude.ai/code/session_01NfwB22aMbwpiGNvUVtAbXL